### PR TITLE
[7125: Airbyte] Mongodb CDC

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
@@ -29,6 +29,16 @@ public class MongoConnectionUtils {
    * @return The configured {@link MongoClient}.
    */
   public static MongoClient createMongoClient(final MongoDbSourceConfig config) {
+    final String sslMode = config.getSslMode();
+    if (MongoSslUtils.isValidSslMode(sslMode)) {
+      MongoSslUtils.setupCertificates(
+        sslMode,
+        config.getCACertificate(),
+        config.getClientCertificate(),
+        config.getClientKey(),
+        config.getClientKeyPassword()
+      );
+    }
     final ConnectionString mongoConnectionString = new ConnectionString(buildConnectionString(config));
 
     final MongoDriverInformation mongoDriverInformation = MongoDriverInformation.builder()

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
@@ -30,7 +30,8 @@ public class MongoConnectionUtils {
    */
   public static MongoClient createMongoClient(final MongoDbSourceConfig config) {
     final String sslMode = config.getSslMode();
-    if (MongoSslUtils.isValidSslMode(sslMode)) {
+    final boolean isSSLEnabled = MongoSslUtils.isValidSslMode(sslMode);
+    if (isSSLEnabled) {
       MongoSslUtils.setupCertificates(
         sslMode,
         config.getCACertificate(),
@@ -47,6 +48,7 @@ public class MongoConnectionUtils {
 
     final MongoClientSettings.Builder mongoClientSettingsBuilder = MongoClientSettings.builder()
         .applyConnectionString(mongoConnectionString)
+        .applyToSslSettings(builder -> builder.enabled(isSSLEnabled))
         .readPreference(ReadPreference.secondaryPreferred());
 
     if (config.hasAuthCredentials()) {

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConnectionUtils.java
@@ -37,6 +37,7 @@ public class MongoConnectionUtils {
         config.getCACertificate(),
         config.getClientCertificate(),
         config.getClientKey(),
+        config.getClientKeyStorePassword(),
         config.getClientKeyPassword()
       );
     }

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConstants.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConstants.java
@@ -41,6 +41,23 @@ public class MongoConstants {
   public static final String FAIL_SYNC_OPTION = "Fail sync";
   public static final String RESYNC_DATA_OPTION = "Re-sync data";
 
+  public static final String PARAM_CA_CERTIFICATE = "ca_certificate";
+  public static final String PARAM_CLIENT_CERTIFICATE = "client_certificate";
+  public static final String PARAM_CLIENT_KEY = "client_key";  
+  public static final String PARAM_CLIENT_KEY_PASSWORD = "client_key_password";
+  public static final String PARAM_SSL_KEY = "ssl_mode";
+  public static final String PARAM_SSL_MODE_KEY = "mode";
+  public static final String PARAM_SSL_MODE_CCV = "CCV";
+
+  public static final String CLIENT_CERTIFICATE = "client.crt";
+  public static final String CLIENT_CA_CERTIFICATE = "client-ca.crt";
+  public static final String CLIENT_KEY = "client.key";
+  public static final String CLIENT_KEY_STORE = "client_key_store.p12";
+  public static final String KEY_STORE_TYPE = "PKCS12";
+  public static final String TRUST_STORE = "truststore.jks";
+  public static final String TRUST_PASSWORD = "truststore_pwd";
+  public static final String TRUST_TYPE = "JKS";
+
   private MongoConstants() {}
 
 }

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConstants.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoConstants.java
@@ -44,7 +44,8 @@ public class MongoConstants {
   public static final String PARAM_CA_CERTIFICATE = "ca_certificate";
   public static final String PARAM_CLIENT_CERTIFICATE = "client_certificate";
   public static final String PARAM_CLIENT_KEY = "client_key";  
-  public static final String PARAM_CLIENT_KEY_PASSWORD = "client_key_password";
+  public static final String PARAM_CLIENT_KEY_PASSWORD_IN = "client_key_password_in";
+  public static final String PARAM_CLIENT_KEY_PASSWORD_OUT = "client_key_password_out";
   public static final String PARAM_SSL_KEY = "ssl_mode";
   public static final String PARAM_SSL_MODE_KEY = "mode";
   public static final String PARAM_SSL_MODE_CCV = "CCV";

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSourceConfig.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSourceConfig.java
@@ -19,6 +19,12 @@ import static io.airbyte.integrations.source.mongodb.MongoConstants.PASSWORD_CON
 import static io.airbyte.integrations.source.mongodb.MongoConstants.RESYNC_DATA_OPTION;
 import static io.airbyte.integrations.source.mongodb.MongoConstants.SCHEMA_ENFORCED_CONFIGURATION_KEY;
 import static io.airbyte.integrations.source.mongodb.MongoConstants.USERNAME_CONFIGURATION_KEY;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_SSL_KEY;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_SSL_MODE_KEY;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_CA_CERTIFICATE;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_CLIENT_CERTIFICATE;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_CLIENT_KEY;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_CLIENT_KEY_PASSWORD;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.OptionalInt;
@@ -47,6 +53,30 @@ public record MongoDbSourceConfig(JsonNode rawConfig) {
   public String getAuthSource() {
     return getDatabaseConfig().has(AUTH_SOURCE_CONFIGURATION_KEY) ? getDatabaseConfig().get(AUTH_SOURCE_CONFIGURATION_KEY).asText(DEFAULT_AUTH_SOURCE)
         : DEFAULT_AUTH_SOURCE;
+  }
+
+  public JsonNode getSSLConfig() {
+    return getDatabaseConfig().get(PARAM_SSL_KEY);
+  }
+
+  public String getSslMode() {
+    return getSSLConfig().has(PARAM_SSL_MODE_KEY) ? getSSLConfig().get(PARAM_SSL_MODE_KEY).asText() : null;
+  }
+
+  public String getCACertificate() {
+    return getSSLConfig().has(PARAM_CA_CERTIFICATE) ? getSSLConfig().get(PARAM_CA_CERTIFICATE).asText() : null;
+  }
+  
+  public String getClientCertificate() {
+    return getSSLConfig().has(PARAM_CLIENT_CERTIFICATE) ? getSSLConfig().get(PARAM_CLIENT_CERTIFICATE).asText() : null;
+  }
+  
+  public String getClientKey() {
+    return getSSLConfig().has(PARAM_CLIENT_KEY) ? getSSLConfig().get(PARAM_CLIENT_KEY).asText() : null;
+  }
+  
+  public String getClientKeyPassword() {
+    return getSSLConfig().has(PARAM_CLIENT_KEY_PASSWORD) ? getSSLConfig().get(PARAM_CLIENT_KEY_PASSWORD).asText() : null;
   }
 
   public Integer getCheckpointInterval() {

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSourceConfig.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoDbSourceConfig.java
@@ -24,7 +24,8 @@ import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_SSL_MO
 import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_CA_CERTIFICATE;
 import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_CLIENT_CERTIFICATE;
 import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_CLIENT_KEY;
-import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_CLIENT_KEY_PASSWORD;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_CLIENT_KEY_PASSWORD_IN;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_CLIENT_KEY_PASSWORD_OUT;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.OptionalInt;
@@ -76,7 +77,11 @@ public record MongoDbSourceConfig(JsonNode rawConfig) {
   }
   
   public String getClientKeyPassword() {
-    return getSSLConfig().has(PARAM_CLIENT_KEY_PASSWORD) ? getSSLConfig().get(PARAM_CLIENT_KEY_PASSWORD).asText() : null;
+    return getSSLConfig().has(PARAM_CLIENT_KEY_PASSWORD_IN) ? getSSLConfig().get(PARAM_CLIENT_KEY_PASSWORD_IN).asText() : null;
+  }
+
+  public String getClientKeyStorePassword() {
+    return getSSLConfig().has(PARAM_CLIENT_KEY_PASSWORD_OUT) ? getSSLConfig().get(PARAM_CLIENT_KEY_PASSWORD_OUT).asText() : null;
   }
 
   public Integer getCheckpointInterval() {

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoSslUtils.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoSslUtils.java
@@ -1,0 +1,143 @@
+package io.airbyte.integrations.source.mongodb;
+
+import static io.airbyte.integrations.source.mongodb.MongoSslUtils.SslMode.CCV;
+import static io.airbyte.integrations.source.mongodb.MongoSslUtils.SslMode.DISABLED;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.PARAM_SSL_MODE_CCV;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.CLIENT_CERTIFICATE;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.CLIENT_CA_CERTIFICATE;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.CLIENT_KEY;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.CLIENT_KEY_STORE;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.KEY_STORE_TYPE;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.TRUST_STORE;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.TRUST_PASSWORD;
+import static io.airbyte.integrations.source.mongodb.MongoConstants.TRUST_TYPE;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MongoSslUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MongoSslUtils.class);
+
+  public static void setupCertificates(
+    final String sslMode,
+    final String caCertificate,
+    final String clientCertificate,
+    final String clientKey,
+    final String clientKeyPassword
+  ) {
+    try {
+      if (getSslVerifyMode(sslMode) == CCV) {
+        LOGGER.info("Preparing SSL certificates for '{}' mode", PARAM_SSL_MODE_CCV);
+        initCertificateStores(
+          caCertificate,
+          clientCertificate,
+          clientKey,
+          getOrGeneratePassword(clientKeyPassword)
+        );
+      }
+    } catch (final IOException | InterruptedException e) {
+      throw new RuntimeException("Failed to import certificate into Java Keystore");
+    }
+  }
+  
+  private static String getOrGeneratePassword(final String clientKeyPassword) {
+    return clientKeyPassword != null && !clientKeyPassword.isEmpty() ? clientKeyPassword : RandomStringUtils.randomAlphanumeric(10);
+  }
+
+  private static void initCertificateStores(
+    final String caCertificate,
+    final String clientCertificate,
+    final String clientKey,
+    final String clientKeyPassword
+  )
+  throws IOException, InterruptedException {
+
+    LOGGER.info("Try to generate '{}'", CLIENT_KEY_STORE);
+    createCertificateFile(CLIENT_CERTIFICATE, clientCertificate);
+    createCertificateFile(CLIENT_KEY, clientKey);
+
+    runProcess(String.format("openssl pkcs12 -export -in %s -inkey %s -out %s -passout pass:%s",
+        CLIENT_CERTIFICATE,
+        CLIENT_KEY,
+        CLIENT_KEY_STORE,
+        clientKeyPassword));
+    LOGGER.info("'{}' Generated", CLIENT_KEY_STORE);
+
+    // Import the SSL certiﬁcate in the truststore
+
+    LOGGER.info("Try to generate '{}'", CLIENT_CA_CERTIFICATE);
+    createCertificateFile(CLIENT_CA_CERTIFICATE, caCertificate);
+    LOGGER.info("'{}' Generated", CLIENT_CA_CERTIFICATE);
+    
+    LOGGER.info("Try to generate '{}'", TRUST_STORE);
+    runProcess(String.format("keytool -import -file %s -alias mongoClient -keystore %s -storepass %s -noprompt",
+        CLIENT_CA_CERTIFICATE,
+        TRUST_STORE,
+        TRUST_PASSWORD));
+    LOGGER.info("'{}' Generated", TRUST_STORE);
+
+    setSystemProperty(clientKeyPassword);
+  }
+
+  private static void runProcess(final String cmd) throws IOException, InterruptedException {
+    ProcessBuilder processBuilder = new ProcessBuilder(cmd.split("\\s+"));
+    Process process = processBuilder.start();    
+    if (!process.waitFor(30, TimeUnit.SECONDS)) {
+        process.destroy();
+        throw new RuntimeException("Timeout while executing: " + cmd);
+    }
+  }
+
+  private static void createCertificateFile(final String fileName, final String fileValue) throws IOException {
+    try (final PrintWriter out = new PrintWriter(fileName, StandardCharsets.UTF_8)) {
+      out.print(fileValue);
+    }
+  }
+
+  private static void setSystemProperty(final String clientKeyPassword) {
+    System.setProperty("javax.net.ssl.keyStoreType", KEY_STORE_TYPE);
+    System.setProperty("javax.net.ssl.keyStore", CLIENT_KEY_STORE);
+    System.setProperty("javax.net.ssl.keyStorePassword", clientKeyPassword);
+    System.setProperty("javax.net.ssl.trustStoreType", TRUST_TYPE);
+    System.setProperty("javax.net.ssl.trustStore", TRUST_STORE);
+    System.setProperty("javax.net.ssl.trustStorePassword", TRUST_PASSWORD);
+  }
+
+  public static boolean isValidSslMode(final String sslMode) {
+    return sslMode != null && !sslMode.isEmpty() && !sslMode.equals(DISABLED.toString());
+  }
+
+  private static SslMode getSslVerifyMode(final String sslMode) {
+    return SslMode.bySpec(sslMode).orElseThrow(() -> new IllegalArgumentException("unexpected ssl mode"));
+  }
+
+  public enum SslMode {
+
+    DISABLED("disable"),
+    CCV("CCV");
+
+    public final List<String> spec;
+
+    SslMode(final String... spec) {
+      this.spec = Arrays.asList(spec);
+    }
+
+    public static Optional<SslMode> bySpec(final String spec) {
+      return Arrays.stream(SslMode.values())
+          .filter(sslMode -> sslMode.spec.contains(spec))
+          .findFirst();
+    }
+
+  }
+
+}

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoSslUtils.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoSslUtils.java
@@ -33,6 +33,7 @@ public class MongoSslUtils {
     final String caCertificate,
     final String clientCertificate,
     final String clientKey,
+    final String clientKeyStorePassword,
     final String clientKeyPassword
   ) {
     try {
@@ -42,6 +43,7 @@ public class MongoSslUtils {
           caCertificate,
           clientCertificate,
           clientKey,
+          clientKeyStorePassword,
           getOrGeneratePassword(clientKeyPassword)
         );
       }
@@ -58,6 +60,7 @@ public class MongoSslUtils {
     final String caCertificate,
     final String clientCertificate,
     final String clientKey,
+    final String clientKeyStorePassword,
     final String clientKeyPassword
   )
   throws IOException, InterruptedException {
@@ -66,10 +69,11 @@ public class MongoSslUtils {
     createCertificateFile(CLIENT_CERTIFICATE, clientCertificate);
     createCertificateFile(CLIENT_KEY, clientKey);
 
-    runProcess(String.format("openssl pkcs12 -export -in %s -inkey %s -out %s -passout pass:%s",
+    runProcess(String.format("openssl pkcs12 -export -in %s -inkey %s -out %s -passout pass:%s -passin pass:%s",
         CLIENT_CERTIFICATE,
         CLIENT_KEY,
         CLIENT_KEY_STORE,
+        clientKeyStorePassword,
         clientKeyPassword));
     LOGGER.info("'{}' Generated", CLIENT_KEY_STORE);
 

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoSslUtils.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoSslUtils.java
@@ -75,11 +75,9 @@ public class MongoSslUtils {
 
     // Import the SSL certiﬁcate in the truststore
 
-    LOGGER.info("Try to generate '{}'", CLIENT_CA_CERTIFICATE);
-    createCertificateFile(CLIENT_CA_CERTIFICATE, caCertificate);
-    LOGGER.info("'{}' Generated", CLIENT_CA_CERTIFICATE);
-    
     LOGGER.info("Try to generate '{}'", TRUST_STORE);
+    createCertificateFile(CLIENT_CA_CERTIFICATE, caCertificate);
+    
     runProcess(String.format("keytool -import -file %s -alias mongoClient -keystore %s -storepass %s -noprompt",
         CLIENT_CA_CERTIFICATE,
         TRUST_STORE,
@@ -101,6 +99,7 @@ public class MongoSslUtils {
   private static void createCertificateFile(final String fileName, final String fileValue) throws IOException {
     try (final PrintWriter out = new PrintWriter(fileName, StandardCharsets.UTF_8)) {
       out.print(fileValue);
+      LOGGER.info("Certificate File '{}' created", fileName);
     }
   }
 

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
@@ -133,6 +133,80 @@
                 "type": "boolean",
                 "always_show": true,
                 "order": 7
+              },
+              "ssl_mode": {
+                "title": "SSL Connection",
+                "description": "SSL connection modes.",
+                "type": "object",
+                "order": 8,
+                "oneOf": [
+                  {
+                    "title": "disable",
+                    "additionalProperties": false,
+                    "description": "Disable SSL.",
+                    "required": ["mode"],
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "const": "disable",
+                        "enum": ["disable"],
+                        "default": "disable",
+                        "order": 0
+                      }
+                    }
+                  },
+                  {
+                    "title": "Client Certificate Validation",
+                    "additionalProperties": false,
+                    "description": "Client Certificate Validation SSL mode.",
+                    "required": [
+                      "mode",
+                      "ca_certificate",
+                      "client_certificate",
+                      "client_key"
+                    ],
+                    "properties": {
+                      "mode": {
+                        "type": "string",
+                        "const": "CCV",
+                        "enum": ["CCV"],
+                        "default": "CCV",
+                        "order": 0
+                      },
+                      "ca_certificate": {
+                        "type": "string",
+                        "title": "CA Certificate",
+                        "description": "CA certificate",
+                        "airbyte_secret": true,
+                        "multiline": true,
+                        "order": 1
+                      },
+                      "client_certificate": {
+                        "type": "string",
+                        "title": "Client Certificate",
+                        "description": "Client certificate",
+                        "airbyte_secret": true,
+                        "multiline": true,
+                        "order": 2
+                      },
+                      "client_key": {
+                        "type": "string",
+                        "title": "Client Key",
+                        "description": "Client key",
+                        "airbyte_secret": true,
+                        "multiline": true,
+                        "order": 3
+                      },
+                      "client_key_password": {
+                        "type": "string",
+                        "title": "Client key password",
+                        "description": "Password for keystorage. If you do not add it - the password will be generated automatically.",
+                        "airbyte_secret": true,
+                        "order": 4
+                      }
+                    }
+                  }
+                ]
               }
             }
           }

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
@@ -197,12 +197,19 @@
                         "multiline": true,
                         "order": 3
                       },
-                      "client_key_password": {
+                      "client_key_password_in": {
                         "type": "string",
                         "title": "Client key password",
-                        "description": "Password for keystorage. If you do not add it - the password will be generated automatically.",
+                        "description": "Password required to read or used to create the client key password. 'openssl pkcs12 -export -passin pass:<client key password to read -inkey file>'",
                         "airbyte_secret": true,
                         "order": 4
+                      },
+                      "client_key_password_out": {
+                        "type": "string",
+                        "title": "Client key store password",
+                        "description": "Password for keystorage. If you do not add it - the password will be generated automatically. openssl pkcs12 -export -passout pass:<client key password to save file with password>",
+                        "airbyte_secret": true,
+                        "order": 5
                       }
                     }
                   }


### PR DESCRIPTION
- Prerequisite
    - airbyte-worker: should have `openssl` and `keytool` 
    - should have appropriate certificates to connect to MongoDB with TLS/SSL enabled

 - SSL Enabled
<img width="483" alt="Screenshot 2024-04-16 at 12 21 38 PM" src="https://github.com/Scanbuy-Inc/airbyte/assets/122939546/dd067103-09f1-4a70-8bc9-e17ab9de02de">



 - SSL Disabled
<img width="490" alt="Screenshot 2024-04-16 at 12 22 28 PM" src="https://github.com/Scanbuy-Inc/airbyte/assets/122939546/5762aa9f-5b79-4810-b5f9-7db7c6f76bb5">


- Reference
    - https://dev.to/arthurgermano/tutorial-configuring-a-local-mongodb-docker-replicaset-with-3nodes-and-tls-4492
    - https://www.percona.com/blog/mongodb-deploy-replica-set-with-transport-encryption-part-3/
    - https://www.ibm.com/docs/en/product-master/12.0.0?topic=mongodb-enabling-ssl
